### PR TITLE
Bugfix reset mu init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ test/CSV/
 test/data/ignore
 docs/build/
 docs/site/
+Ideas/*
+ideas.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Juniper.jl Changelog
 
+### v0.1.2
+- Bugfix: Reset of `mu_init` in Ipopt options to have the default `mu_init` if `solve` is called again 
+
 ### v0.1.1
 - Freemodel for commerical nlp solvers with license restrictions
 - More convenient parallel options 

--- a/src/model.jl
+++ b/src/model.jl
@@ -268,7 +268,7 @@ function MathProgBase.optimize!(m::JuniperModel)
     
     (:All in ps || :Info in ps || :Timing in ps) && println("Time for relaxation: ", m.soltime)
     m.objval   = getobjectivevalue(m.model)
-    m.solution = getvalue(x)
+    m.solution = getvalue(m.x)
 
     internal_model = internalmodel(m.model)
     if method_exists(MathProgBase.freemodel!, Tuple{typeof(internal_model)})


### PR DESCRIPTION
reset mu init every time so that solving problem after problem starts with the correct (default mu init parameter)

If we decide to have a fixed mu init every time after the root relaxation we can set it once and reset it once. Don't know whether it might be reasonable to later reduce the parameter further therefore it is in the process node function atm. 

It shouldn't produce  any noticeable overhead.