### PR TITLE
mip_gap if objval=0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 test/load_mod.jl
-test/current.jl
-test/current_moi.jl
+test/current*.jl
 test/JuniperLib.jl
 test/CSV/
 test/debug.json

--- a/src/bb_user_limits.jl
+++ b/src/bb_user_limits.jl
@@ -4,6 +4,10 @@ function isbreak_mip_gap(tree)
         b = tree.best_bound
         f = incu.objval
         gap = abs(b-f)/abs(f)
+        # if f and g are 0 the gap would be NaN but it's gap=0
+        if isapprox(b,f,atol=tree.options.atol)
+            gap = 0 # doesn't really equal 0 but should break 
+        end
         if gap <= tree.options.mip_gap
             default_opts = get_default_options()
             if tree.options.mip_gap > default_opts.mip_gap


### PR DESCRIPTION
If `objval = 0` then normal calculation of the gap is `NaN` even if `best_bound=0`. 