### PR TITLE
Juniper in Project toml docs, deprecation changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,8 +22,8 @@ MathOptInterface = "^0.8.4"
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 MINLPTests = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Cbc", "Ipopt", "Logging", "MINLPTests"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Juniper = "2ddba703-00a4-53a7-87a5-e8b9971dde84"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,10 @@
 using Documenter, Juniper
 
 makedocs(
-    modules = [Juniper],
-    format = :html,
+    # See https://github.com/JuliaDocs/Documenter.jl/issues/868
+    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
+    # See https://github.com/JuliaOpt/JuMP.jl/issues/1576
+    strict = true,
     sitename = "Juniper",
     pages = [
         "Home" => "index.md",
@@ -14,9 +16,5 @@ makedocs(
 )
 
 deploydocs(
-    deps = nothing,
-    make = nothing,
-    target = "build",
     repo = "github.com/lanl-ansi/Juniper.jl.git",
-    julia = "1.0"
 )


### PR DESCRIPTION
Not sure whether it will fix the bug of documenter currently in master (only appears to be when in master all the time :/ )
Nevertheless it removes deprecation warnings on documenter and uses the new suggestion structure of the `make.jl` file.