### PR TITLE
allow locally solved (not only almost) for ma27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
 cache:
  directories:
    - /home/travis/.julia

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ os:
 julia:
   - 1.0
   - 1.1
-  - 1.2
+  - nightly
+  
+matrix:
+  allow_failures:
+    - julia: nightly
+
 cache:
  directories:
    - /home/travis/.julia

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1104,7 +1104,7 @@ end
     @test Juniper.getnsolutions(internalmodel(m)) >= 1
 end
 
-# this test has a lot "Only almost locally solved" warnings
+# this test has a lot "Only almost locally solved" warnings (in mumps at least)
 @testset "Sum 1/x = 2" begin
     println("==================================")
     println("Sum 1/x = 2")
@@ -1120,7 +1120,8 @@ end
 
     status = solve(m)
 
-    @test status == MOI.ALMOST_LOCALLY_SOLVED
+    # in mumps/on travis this returns ALMOST_LOCALLY_SOLVED but with ma27/locally it is LOCALLY_SOLVED
+    @test Juniper.state_is_optimal(status; allow_almost=true)
     @test isapprox(2, sum(1/v for v in JuMP.value.(x)), atol=opt_atol)
 end
 


### PR DESCRIPTION
The suggested test in #130 doesn't produce ALMOST_LOCALLY_SOLVED and it shouldn't fail the test if it's better ;) 
+ test for the new julia version 1.2.0 on travis

Can we be sure that it passes 1.1 if it passes 1.0 and 1.2 @ccoffrin ? Then we can remove the 1.1 test for better performance in travis.