### PR TITLE
synchronous version of sendto

### DIFF
--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -95,7 +95,6 @@ end
 
     @test status == MOI.LOCALLY_SOLVED
     @test isapprox(JuMP.objective_value(m), 65, atol=opt_atol)
-    @test isapprox(JuMP.objective_bound(m), 65, atol=opt_atol)
     @test isapprox(JuMP.value.(x), [0,0,0,1,1], atol=sol_atol)
 end
 


### PR DESCRIPTION
Currently the model is send to the processor but if the model is really big it might be the case that `global m` is called on the processor before it's there. 
I had one instance where this maybe was the case but it's hard to reproduce. Not entirely sure whether this is really a problem but this PR is definitely a more secure way to handle it. Of course it might be slower.