### PR TITLE
disable fpump in optimize! when all options are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Juniper.jl Changelog
 
+### 0.6.1
+- Bugfix: Use feasibility pump by default if MIP solver is used [#183](https://github.com/lanl-ansi/Juniper.jl/pull/183)
+
 ### 0.6.0
 - Support for JuMP v0.21.0
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Juniper"
 uuid = "2ddba703-00a4-53a7-87a5-e8b9971dde84"
 authors = ["Ole Kröger <o.kroeger@opensourc.es>", "Kaarthik Sundar kaarthik@lanl.gov"]
 repo = "https://github.com/lanl-ansi/Juniper.jl.git"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -94,16 +94,7 @@ function combine_options(options)
         end
     end
 
-    #= will be set with RawParameter now
-    if !haskey(options_dict, :nl_solver)
-        @error "The option nl_solver has to be set i.e with nl_solver = Ipopt.Optimizer"
-    end
-    =#
-
     defaults = get_default_options()
-    if defaults.feasibility_pump == true && (!haskey(options_dict, :mip_solver) || options_dict[:mip_solver] === nothing)
-        defaults.feasibility_pump = false
-    end
 
     # if gain mu is specified we shouldn't change it later
     if haskey(options_dict, :gain_mu)

--- a/test/fpump.jl
+++ b/test/fpump.jl
@@ -48,19 +48,21 @@ end
     @NLconstraint(m, special_constr_fct(x[1],x[2]) == 0)
     @objective(m, Max, sum(x))
 
-    set_optimizer(m, optimizer_with_attributes(
+    optimizer = optimizer_with_attributes(
         Juniper.Optimizer,
         DefaultTestSolver(
             branch_strategy=:MostInfeasible,
-            feasibility_pump = true,
             time_limit = 1,
             mip_solver=optimizer_with_attributes(Cbc.Optimizer, "logLevel" => 0),
             registered_functions=[Juniper.register(register_args...; autodiff=true)]
         )...
-    ))
+    )
+    set_optimizer(m, optimizer)
 
     status = solve(m)
 
+    # should have feasibility_pump be set to true
+    @test MOI.get(m, MOI.RawParameter(:feasibility_pump))
     @test Juniper.getnsolutions(internalmodel(m)) >= 1
 end
 


### PR DESCRIPTION
Bugfix for not using fpump if mip solver exists @ccoffrin 