### PR TITLE
Restore randomnes after optimizing with Juniper.

### DIFF
--- a/src/BnBTree.jl
+++ b/src/BnBTree.jl
@@ -458,12 +458,10 @@ function pmap(f, tree, last_table_arr, time_bnb_solve_start,
     still_running = true
     run_counter = 0
     counter = 0
-    o_seed = abs(rand(Int))
     for p=2:np
-        seed = Random.seed!
+        seed = i -> Random.seed!(JUNIPER_RNG, i)
         remotecall_fetch(seed, p, 1)
     end
-    Random.seed!(o_seed)
     @sync begin
         for p=2:np
             @async begin

--- a/src/BnBTree.jl
+++ b/src/BnBTree.jl
@@ -458,11 +458,12 @@ function pmap(f, tree, last_table_arr, time_bnb_solve_start,
     still_running = true
     run_counter = 0
     counter = 0
-
+    o_seed = abs(rand(Int))
     for p=2:np
         seed = Random.seed!
         remotecall_fetch(seed, p, 1)
     end
+    Random.seed!(o_seed)
     @sync begin
         for p=2:np
             @async begin

--- a/src/Juniper.jl
+++ b/src/Juniper.jl
@@ -5,6 +5,8 @@ using JuMP: @variable, @constraint, @objective, Model, optimizer_with_attributes
 using JSON
 using LinearAlgebra
 using Random
+const JUNIPER_RNG = MersenneTwister(1)
+
 using Distributed
 using Statistics
 

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -336,7 +336,7 @@ function MOI.optimize!(model::Optimizer)
     if model.options.feasibility_pump && model.options.mip_solver === nothing
         model.options.feasibility_pump = false
     end
-
+    seed = abs(rand(Int))
     Random.seed!(1)
     MOI.initialize(model.nlp_data.evaluator, [:ExprGraph])
     
@@ -392,6 +392,7 @@ function MOI.optimize!(model::Optimizer)
         if jp.options.debug && jp.options.debug_write
             write(jp.options.debug_file_path, JSON.json(jp.debugDict))
         end
+        Random.seed!(seed)
         return
     end
 
@@ -440,6 +441,7 @@ function MOI.optimize!(model::Optimizer)
         jp.solution = jp.relaxation_solution
     end
     jp.soltime = time()-jp.start_time
+    Random.seed!(seed)
 
     (:All in ps || :Info in ps) && println("Obj: ",jp.objval)
     
@@ -451,6 +453,7 @@ function MOI.optimize!(model::Optimizer)
     if jp.options.debug && jp.options.debug_write
         write(jp.options.debug_file_path, JSON.json(jp.debugDict))
     end
+
 end 
 
 getnsolutions(m::JuniperProblem) = m.nsolutions

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -336,8 +336,7 @@ function MOI.optimize!(model::Optimizer)
     if model.options.feasibility_pump && model.options.mip_solver === nothing
         model.options.feasibility_pump = false
     end
-    seed = abs(rand(Int))
-    Random.seed!(1)
+    Random.seed!(JUNIPER_RNG, 1)
     MOI.initialize(model.nlp_data.evaluator, [:ExprGraph])
     
     if ~isa(model.nlp_data.evaluator, EmptyNLPEvaluator)
@@ -392,7 +391,6 @@ function MOI.optimize!(model::Optimizer)
         if jp.options.debug && jp.options.debug_write
             write(jp.options.debug_file_path, JSON.json(jp.debugDict))
         end
-        Random.seed!(seed)
         return
     end
 
@@ -441,7 +439,6 @@ function MOI.optimize!(model::Optimizer)
         jp.solution = jp.relaxation_solution
     end
     jp.soltime = time()-jp.start_time
-    Random.seed!(seed)
 
     (:All in ps || :Info in ps) && println("Obj: ",jp.objval)
     

--- a/src/fpump.jl
+++ b/src/fpump.jl
@@ -316,8 +316,7 @@ Run the feasibility pump
 """
 function fpump(optimizer, m)
     
-    seed = abs(rand(Int))
-    Random.seed!(1)
+    Random.seed!(JUNIPER_RNG, 1)
 
     if are_type_correct(m.relaxation_solution, m.var_type, m.disc2var_idx, m.options.atol)
         return Incumbent(m.relaxation_objval, m.relaxation_solution, only_almost_solved(m.status))
@@ -468,8 +467,6 @@ function fpump(optimizer, m)
     m.fpump_info[:obj] = NaN
     m.fpump_info[:gap] = NaN
     check_print(ps,[:Info]) && println("FP: No integral solution found")
-    
-    Random.seed!(seed)
     
     return nothing
 end

--- a/src/fpump.jl
+++ b/src/fpump.jl
@@ -315,6 +315,8 @@ end
 Run the feasibility pump
 """
 function fpump(optimizer, m)
+    
+    seed = abs(rand(Int))
     Random.seed!(1)
 
     if are_type_correct(m.relaxation_solution, m.var_type, m.disc2var_idx, m.options.atol)
@@ -466,5 +468,8 @@ function fpump(optimizer, m)
     m.fpump_info[:obj] = NaN
     m.fpump_info[:gap] = NaN
     check_print(ps,[:Info]) && println("FP: No integral solution found")
+    
+    Random.seed!(seed)
+    
     return nothing
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -51,11 +51,11 @@ function generate_random_restart(m; cont=true)
         end             
 
         if m.var_type[i] == :Cont || cont
-            push!(values,(ubi-lbi)*rand()+lbi)
+            push!(values,(ubi-lbi)*rand(JUNIPER_RNG;)+lbi)
         else
             lbi = Int(round(lbi))
             ubi = Int(round(ubi))
-            push!(values, rand(lbi:ubi))
+            push!(values, rand(JUNIPER_RNG,lbi:ubi))
         end
     end
     return values

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -20,6 +20,10 @@ include("basic/gamsworld.jl")
     @NLconstraint(m, x^2 >= 17)
    
     status = solve(m)
+    rand_num = rand()
+    status = solve(m)
+    @test rand() != rand_num
+
     inner = internalmodel(m)
     @test JuMP.termination_status(m) == MOI.LOCALLY_SOLVED
     @test JuMP.primal_status(m) == MOI.FEASIBLE_POINT


### PR DESCRIPTION
In order to get reproducible results, Juniper sets  `Random.seed!` at some few places. This makes `rand()` basically useless, when used in a loop together with Juniper:
```julia
vals = zeros(10)
for i = 1:10
    m = some_model_generating_function(rand(); model = Model(Juniper.Optimizer()))
    optimize!(m)
    vals[i] = objective_value(m)
end
```
The entries of `vals[2:10]` are all the same. This is because when calling `optimize!` for the first time, Juniper sets the seed and hence, when calling `rand()` afterwards, it will always return the same number. 

This PR resolves the problem by storing a random number before setting the seed and resetting the seed to this random number,  before returning a solution. 
