### PR TITLE
remove return undefined value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Juniper.jl Changelog
 
+### v0.7.1
+- Bugfix `set_subsolver_option!` nothing should be returned if `subsolver_name` doesn't match [PR #214](https://github.com/lanl-ansi/Juniper.jl/pull/214)
+
 ### v0.7.0
 - Removed JuMP dependency [PR #207 by blegat](https://github.com/lanl-ansi/Juniper.jl/pull/207)
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Juniper"
 uuid = "2ddba703-00a4-53a7-87a5-e8b9971dde84"
 authors = ["Ole Kröger <o.kroeger@opensourc.es>", "Kaarthik Sundar kaarthik@lanl.gov"]
 repo = "https://github.com/lanl-ansi/Juniper.jl.git"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/util.jl
+++ b/src/util.jl
@@ -286,7 +286,6 @@ function set_subsolver_option!(model::MOI.ModelLike, subsolver_name::String, att
     if occursin(subsolver_name, MOI.get(model, MOI.SolverName()))
         return set_subsolver_option!(model, attr, change)
     end
-    return value
 end
 function set_subsolver_option!(model::MOI.ModelLike, subsolver_name::String, param::String, change)
     set_subsolver_option!(model, subsolver_name, MOI.RawParameter(param), change)


### PR DESCRIPTION
Part of #213 
The `value` that was returned didn't exist but also no return value is needed here.
