### PR TITLE
add slow progress due to numerical instability

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -186,7 +186,7 @@ end
 Returns true if either ALMOST_OPTIMAL or ALMOST_LOCALLY_SOLVED
 """
 function only_almost_solved(state::MOI.TerminationStatusCode)
-    return state == MOI.ALMOST_OPTIMAL || state == MOI.ALMOST_LOCALLY_SOLVED
+    return state == MOI.ALMOST_OPTIMAL || state == MOI.ALMOST_LOCALLY_SOLVED || state == MOI.SLOW_PROGRESS
 end
 
 """
@@ -201,7 +201,8 @@ function state_is_optimal(
     return state == MOI.OPTIMAL ||
            state == MOI.LOCALLY_SOLVED ||
            (allow_almost && state == MOI.ALMOST_LOCALLY_SOLVED) ||
-           (allow_almost && state == MOI.ALMOST_OPTIMAL)
+           (allow_almost && state == MOI.ALMOST_OPTIMAL) ||
+           (allow_almost && state == MOI.SLOW_PROGRESS)
 end
 
 """


### PR DESCRIPTION
When dealing with numerical problems, Mosek can return SLOW_PROGRESS in the termination status. 
Sometimes, in my experiments, the optimal solution wasn't reached because of this, maybe Juniper treats it as Infeasible, but not necessarily is an infeasible solution, most of the times is almost feasible solution or almost optimal solution.
Links:
https://docs.mosek.com/latest/capi/response-codes.html
>MSK_RES_TRM_STALL (10006)
The optimizer is terminated due to slow progress.
Stalling means that numerical problems prevent the optimizer from making reasonable progress and that it makes no sense to continue. In many cases this happens if the problem is badly scaled or otherwise ill-conditioned. There is no guarantee that the solution will be feasible or optimal. However, often stalling happens near the optimum, and the returned solution may be of good quality. Therefore, it is recommended to check the status of the solution. If the solution status is optimal the solution is most likely good enough for most practical purposes.
Please note that if a linear optimization problem is solved using the interior-point optimizer with basis identification turned on, the returned basic solution likely to have high accuracy, even though the optimizer stalled.
Some common causes of stalling are a) badly scaled models, b) near feasible or near infeasible problems.

https://groups.google.com/g/mosek/c/v7lbk__Gr4s
>My best guess is Mosek computes a fairly accurate solution. And most likely it is good enough for all practical purposes.
You are aware you always get an approximate solution so even if Mosek had not said slow progress you would have to evaluate whether the solution is accurate enough.
Btw you can see Mosek warns about a large number in the objective. That is because such things makes your problem harder numerically.

https://gitter.im/JuliaOpt/SumOfSquares.jl?at=5d02c3f12d3f89045fb6b444
>With SLOW_PROGRESS you could also check primal_status to check if you have a feasible solution even if it's not optimal
