### PR TITLE
Prep for v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### v0.9.1
 - Updated to JuMP v1.0
+- Fixed the return values when querying `MOI.PrimalStatus` and `MOI.DualStatus`.
+  [PR #250](https://github.com/lanl-ansi/Juniper.jl/pull/250)
 
 ### v0.9.0
 - Updated to MathOptInterface v1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Juniper.jl Changelog
 
-### v0.9.1
-- Updated to JuMP v1.0
+
+### v0.9.2
 - Fixed the return values when querying `MOI.PrimalStatus` and `MOI.DualStatus`.
   [PR #250](https://github.com/lanl-ansi/Juniper.jl/pull/250)
+
+### v0.9.1
+- Updated to JuMP v1.0
 
 ### v0.9.0
 - Updated to MathOptInterface v1.0

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Juniper"
 uuid = "2ddba703-00a4-53a7-87a5-e8b9971dde84"
 authors = ["Ole Kröger <o.kroeger@opensourc.es>", "Kaarthik Sundar kaarthik@lanl.gov"]
 repo = "https://github.com/lanl-ansi/Juniper.jl.git"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"


### PR DESCRIPTION
Project.toml was already updated, so just looks like we didn't tag a release.