### PR TITLE
Replaced JuMP with Juniper in the installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install Juniper using the Julia package manager:
 
 ```julia
 import Pkg
-Pkg.add("JuMP")
+Pkg.add("Juniper")
 ```
 
 ## Use with JuMP


### PR DESCRIPTION
The installation instructions of `Juniper` on the `README` file was directing one to install `JuMP` instead.