### PR TITLE
Fix integer fractionals bug when using HiGHS

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -315,7 +315,7 @@ function evaluate_objective(
     if jp.nlp_data !== nothing && jp.nlp_data.has_objective
         return MOI.eval_objective(jp.nlp_data.evaluator, xs)
     elseif jp.objective !== nothing
-        return MOIU.eval_variables(vi -> xs[vi.value], jp.objective)
+        return MOIU.eval_variables(vi -> xs[vi.value], jp.model, jp.objective)
     else
         return 0.0
     end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1055,6 +1055,28 @@ include("basic/gamsworld.jl")
         @test isapprox(2, sum(1 / v for v in JuMP.value.(x)), atol = opt_atol)
     end
 
+    @testset "Integer fractional objective w/ HiGHS" begin
+        println("==================================")
+        println("Integer fractional objective w/ HiGHS")
+        println("==================================")
+        m = Model(
+            optimizer_with_attributes(
+                Juniper.Optimizer,
+                DefaultTestSolver(
+                    mip_solver = optimizer_with_attributes(
+                        HiGHS.Optimizer,
+                        "output_flag" => false,
+                    ),
+                )...,
+            ),
+        )
+        @variable(m, 1 <= x <= 5, Int)
+        @variable(m, 1 <= y <= 5, Int)
+        @objective(m, Max, x / y)
+        optimize!(m)
+        @test termination_status(m) == MOI.LOCALLY_SOLVED
+    end
+
     #this test has an expression where a variable will be dereferenced twice
     @testset "Nested variable reference" begin
         println("==================================")


### PR DESCRIPTION
Hi,

There seems to be a bug with integer fractional expressions when using HiGHS. MWE:

```julia
julia> using JuMP, HiGHS, Ipopt, Juniper

julia> ipopt = optimizer_with_attributes(Ipopt.Optimizer);

julia> highs = optimizer_with_attributes(HiGHS.Optimizer);

julia> juniper = optimizer_with_attributes(
           Juniper.Optimizer,
           "nl_solver" => ipopt,
           "mip_solver" => highs,
       );

julia> mdl = Model(juniper);

julia> @variable(mdl, 1 <= x <= 5, Int);

julia> @variable(mdl, 1 <= y <= 5, Int);

julia> @objective(mdl, Max, x / y);

julia> optimize!(mdl)
nl_solver   : MathOptInterface.OptimizerWithAttributes(Ipopt.Optimizer, Pair{MathOptInterface.AbstractOptimizerAttribute, Any}[])
mip_solver  : MathOptInterface.OptimizerWithAttributes(HiGHS.Optimizer, Pair{MathOptInterface.AbstractOptimizerAttribute, Any}[])
log_levels  : [:Options, :Table, :Info]

#Variables: 2
#IntBinVar: 2
Obj Sense: Max

This is Ipopt version 3.14.17, running with linear solver MUMPS 5.7.3.

Number of nonzeros in equality constraint Jacobian...:        0
Number of nonzeros in inequality constraint Jacobian.:        0
Number of nonzeros in Lagrangian Hessian.............:        3

Total number of variables............................:        2
                     variables with only lower bounds:        0
                variables with lower and upper bounds:        2
                     variables with only upper bounds:        0
Total number of equality constraints.................:        0
Total number of inequality constraints...............:        0
        inequality constraints with only lower bounds:        0
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        0

iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  1.0000000e+00 0.00e+00 9.90e-09  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  1.0000000e+00 0.00e+00 8.75e-11  -1.0 9.95e-02    -  1.00e+00 1.00e+00f  1
   2  1.0000000e+00 0.00e+00 2.00e-11  -2.5 5.35e-02    -  1.00e+00 1.00e+00f  1
   3  1.0000023e+00 0.00e+00 5.60e-11  -3.8 9.77e-02    -  1.00e+00 1.00e+00f  1
   4  1.0000447e+00 0.00e+00 2.23e-12  -5.7 2.14e-02    -  1.00e+00 1.00e+00f  1
   5  1.0035347e+00 0.00e+00 1.83e-13  -8.6 4.58e-03    -  9.93e-01 1.00e+00f  1
   6  1.9656069e+00 0.00e+00 6.37e-08  -8.6 1.32e+01    -  7.03e-01 7.25e-02f  2
   7  2.6613486e+00 0.00e+00 1.27e-08  -8.6 7.65e-01    -  7.77e-01 1.00e+00f  1
   8  4.5692067e+00 0.00e+00 7.71e-10 -12.9 1.92e+00    -  9.60e-01 8.12e-01f  1
   9  4.9949715e+00 0.00e+00 2.38e-14 -12.9 4.26e-01    -  1.00e+00 1.00e+00f  1
iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
  10  4.9999750e+00 0.00e+00 2.84e-17 -12.9 5.00e-03    -  1.00e+00 1.00e+00f  1

Number of Iterations....: 10

                                   (scaled)                 (unscaled)
Objective...............:  -4.9999750159080130e-08    4.9999750159080127e+00
Dual infeasibility......:   2.8415245409890395e-17    2.8415245409890395e-09
Constraint violation....:   0.0000000000000000e+00    0.0000000000000000e+00
Variable bound violation:   0.0000000000000000e+00    0.0000000000000000e+00
Complementarity.........:   1.2545991727614336e-13    1.2545991727614336e-05
Overall NLP error.......:   1.2545991727614336e-13    1.2545991727614336e-05


Number of objective function evaluations             = 16
Number of objective gradient evaluations             = 11
Number of equality constraint evaluations            = 0
Number of inequality constraint evaluations          = 0
Number of equality constraint Jacobian evaluations   = 0
Number of inequality constraint Jacobian evaluations = 0
Number of Lagrangian Hessian evaluations             = 10
Total seconds in IPOPT                               = 0.002

EXIT: Optimal Solution Found.
This is Ipopt version 3.14.17, running with linear solver MUMPS 5.7.3.

Number of nonzeros in equality constraint Jacobian...:        0
Number of nonzeros in inequality constraint Jacobian.:        0
Number of nonzeros in Lagrangian Hessian.............:        3

Total number of variables............................:        2
                     variables with only lower bounds:        0
                variables with lower and upper bounds:        2
                     variables with only upper bounds:        0
Total number of equality constraints.................:        0
Total number of inequality constraints...............:        0
        inequality constraints with only lower bounds:        0
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        0

iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  1.0000000e+00 0.00e+00 9.90e-09  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  1.0000000e+00 0.00e+00 8.75e-11  -1.0 9.95e-02    -  1.00e+00 1.00e+00f  1
   2  1.0000000e+00 0.00e+00 2.00e-11  -2.5 5.35e-02    -  1.00e+00 1.00e+00f  1
   3  1.0000023e+00 0.00e+00 5.60e-11  -3.8 9.77e-02    -  1.00e+00 1.00e+00f  1
   4  1.0000447e+00 0.00e+00 2.23e-12  -5.7 2.14e-02    -  1.00e+00 1.00e+00f  1
   5  1.0035347e+00 0.00e+00 1.83e-13  -8.6 4.58e-03    -  9.93e-01 1.00e+00f  1
   6  1.9656069e+00 0.00e+00 6.37e-08  -8.6 1.32e+01    -  7.03e-01 7.25e-02f  2
   7  2.6613486e+00 0.00e+00 1.27e-08  -8.6 7.65e-01    -  7.77e-01 1.00e+00f  1
   8  4.5692067e+00 0.00e+00 7.71e-10 -12.9 1.92e+00    -  9.60e-01 8.12e-01f  1
   9  4.9949715e+00 0.00e+00 2.38e-14 -12.9 4.26e-01    -  1.00e+00 1.00e+00f  1
iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
  10  4.9999750e+00 0.00e+00 2.84e-17 -12.9 5.00e-03    -  1.00e+00 1.00e+00f  1

Number of Iterations....: 10

                                   (scaled)                 (unscaled)
Objective...............:  -4.9999750159080130e-08    4.9999750159080127e+00
Dual infeasibility......:   2.8415245409890395e-17    2.8415245409890395e-09
Constraint violation....:   0.0000000000000000e+00    0.0000000000000000e+00
Variable bound violation:   0.0000000000000000e+00    0.0000000000000000e+00
Complementarity.........:   1.2545991727614336e-13    1.2545991727614336e-05
Overall NLP error.......:   1.2545991727614336e-13    1.2545991727614336e-05


Number of objective function evaluations             = 16
Number of objective gradient evaluations             = 11
Number of equality constraint evaluations            = 0
Number of inequality constraint evaluations          = 0
Number of equality constraint Jacobian evaluations   = 0
Number of inequality constraint Jacobian evaluations = 0
Number of Lagrangian Hessian evaluations             = 10
Total seconds in IPOPT                               = 0.002

EXIT: Optimal Solution Found.
Status of relaxation: LOCALLY_SOLVED
Time for relaxation: 0.007776975631713867
Relaxation Obj: 4.999975015908013

       MIPobj              NLPobj       Time
=============================================
This is Ipopt version 3.14.17, running with linear solver MUMPS 5.7.3.

Number of nonzeros in equality constraint Jacobian...:        0
Number of nonzeros in inequality constraint Jacobian.:        0
Number of nonzeros in Lagrangian Hessian.............:        2

Total number of variables............................:        2
                     variables with only lower bounds:        0
                variables with lower and upper bounds:        2
                     variables with only upper bounds:        0
Total number of equality constraints.................:        0
Total number of inequality constraints...............:        0
        inequality constraints with only lower bounds:        0
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        0

iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  1.6999958e-03 0.00e+00 8.00e-02  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  2.7877146e-02 0.00e+00 8.88e-16  -1.0 9.74e-02    -  1.00e+00 1.00e+00f  1
   2  9.7726262e-03 0.00e+00 1.33e-04  -2.5 5.35e-02    -  9.99e-01 1.00e+00f  1
   3  2.5230305e-03 0.00e+00 3.47e-16  -3.8 3.67e-02    -  1.00e+00 1.00e+00f  1
   4  7.0786268e-04 0.00e+00 9.10e-17  -3.8 1.79e-02    -  1.00e+00 1.00e+00f  1
   5  1.7806292e-04 0.00e+00 2.57e-16  -5.7 9.90e-03    -  1.00e+00 1.00e+00f  1
   6  4.5441562e-05 0.00e+00 6.73e-16  -5.7 4.93e-03    -  1.00e+00 1.00e+00f  1
   7  1.2301134e-05 0.00e+00 5.12e-17  -5.7 2.42e-03    -  1.00e+00 1.00e+00f  1
   8  3.0767832e-06 0.00e+00 8.04e-17  -8.6 1.30e-03    -  1.00e+00 1.00e+00f  1
   9  7.7042979e-07 0.00e+00 5.25e-16  -8.6 6.51e-04    -  1.00e+00 1.00e+00f  1
iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
  10  1.9385268e-07 0.00e+00 8.57e-16  -8.6 3.25e-04    -  1.00e+00 1.00e+00f  1
  11  4.9719313e-08 0.00e+00 7.83e-16  -8.6 1.61e-04    -  1.00e+00 1.00e+00f  1
  12  1.3711966e-08 0.00e+00 5.22e-16  -8.6 7.89e-05    -  1.00e+00 1.00e+00f  1
  13  3.8962866e-09 0.00e+00 1.07e-16  -9.0 4.06e-05    -  1.00e+00 1.00e+00f  1

Number of Iterations....: 13

                                   (scaled)                 (unscaled)
Objective...............:   3.8962866266700757e-09    3.8962866266700757e-09
Dual infeasibility......:   1.0725469991312853e-16    1.0725469991312853e-16
Constraint violation....:   0.0000000000000000e+00    0.0000000000000000e+00
Variable bound violation:   0.0000000000000000e+00    0.0000000000000000e+00
Complementarity.........:   4.2046138600504748e-09    4.2046138600504748e-09
Overall NLP error.......:   4.2046138600504748e-09    4.2046138600504748e-09


Number of objective function evaluations             = 14
Number of objective gradient evaluations             = 14
Number of equality constraint evaluations            = 0
Number of inequality constraint evaluations          = 0
Number of equality constraint Jacobian evaluations   = 0
Number of inequality constraint Jacobian evaluations = 0
Number of Lagrangian Hessian evaluations             = 1
Total seconds in IPOPT                               = 0.002

EXIT: Optimal Solution Found.
         -                  0.0          0.0
ERROR: MethodError: no method matching eval_variables(::Juniper.var"#114#115"{Vector{Float64}}, ::MathOptInterface.ScalarNonlinearFunction)
The function `eval_variables` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  eval_variables(::Function, ::MathOptInterface.VariableIndex)
   @ MathOptInterface ~/.julia/packages/MathOptInterface/jGuEH/src/Utilities/functions.jl:131
  eval_variables(::Function, ::MathOptInterface.VectorOfVariables)
   @ MathOptInterface ~/.julia/packages/MathOptInterface/jGuEH/src/Utilities/functions.jl:152
  eval_variables(::Function, ::MathOptInterface.ScalarAffineTerm)
   @ MathOptInterface ~/.julia/packages/MathOptInterface/jGuEH/src/Utilities/functions.jl:122
  ...

Stacktrace:
  [1] evaluate_objective(optimizer::Juniper.Optimizer, jp::Juniper.JuniperProblem, xs::Vector{Float64})
    @ Juniper ~/docs/forks/Juniper.jl/src/util.jl:318
  [2] generate_real_nlp(optimizer::Juniper.Optimizer, m::Juniper.JuniperProblem, sol::Vector{Float64}; random_start::Bool)
    @ Juniper ~/docs/forks/Juniper.jl/src/fpump.jl:185
  [3] generate_real_nlp(optimizer::Juniper.Optimizer, m::Juniper.JuniperProblem, sol::Vector{Float64})
    @ Juniper ~/docs/forks/Juniper.jl/src/fpump.jl:183
  [4] fpump(optimizer::Juniper.Optimizer, m::Juniper.JuniperProblem)
    @ Juniper ~/docs/forks/Juniper.jl/src/fpump.jl:447
  [5] optimize!(model::Juniper.Optimizer)
    @ Juniper ~/docs/forks/Juniper.jl/src/MOI_wrapper/MOI_wrapper.jl:341
  [6] optimize!
    @ ~/.julia/packages/MathOptInterface/jGuEH/src/Bridges/bridge_optimizer.jl:367 [inlined]
  [7] optimize!
    @ ~/.julia/packages/MathOptInterface/jGuEH/src/MathOptInterface.jl:122 [inlined]
  [8] optimize!(m::MathOptInterface.Utilities.CachingOptimizer{…})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/jGuEH/src/Utilities/cachingoptimizer.jl:327
  [9] optimize!(model::Model; ignore_optimize_hook::Bool, _differentiation_backend::MathOptInterface.Nonlinear.SparseReverseMode, kwargs::@Kwargs{})
    @ JuMP ~/.julia/packages/JuMP/RGIK3/src/optimizer_interface.jl:595
 [10] optimize!(model::Model)
    @ JuMP ~/.julia/packages/JuMP/RGIK3/src/optimizer_interface.jl:546
 [11] top-level scope
    @ REPL[27]:1
 [12] top-level scope
    @ none:1
Some type information was truncated. Use `show(err)` to see complete types.
```

The fix is suggested in the deprecation warning of `MOIU.eval_variables`, so to be honest I don't fully know what its changing, but it gets this example working again :)

Thanks for the package!!